### PR TITLE
Inventory icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Displays the following information:
 * Prayer
 * Absorption in NMZ
 * Amount of cannonballs in your cannon
+* Amount of items in your inventory
 
 
 * Icons can be disabled individually.

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.trayindicators'
-version = '1.4'
+version = '1.5'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Tray Indicators
 author=DMAD777
 support=https://github.com/DMAD777/tray-indicators/issues
-description=Displays your hitpoints, prayer or absorption in the system tray.
-tags=
+description=Displays your hitpoints, prayer, absorption, cannon ammo, inventory count in the system tray.
+tags=notifications,icon,tray,systemtray,indicators,hitpoints,prayer,absorption,cannon,inventory
 plugins=com.trayindicators.TrayIndicatorsPlugin

--- a/src/main/java/com/trayindicators/TrayIndicatorsConfig.java
+++ b/src/main/java/com/trayindicators/TrayIndicatorsConfig.java
@@ -24,12 +24,12 @@
  */
 package com.trayindicators;
 
+import java.awt.Color;
+
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
-
-import java.awt.Color;
 
 @ConfigGroup("Tray Indicators")
 public interface TrayIndicatorsConfig extends Config
@@ -229,6 +229,107 @@ public interface TrayIndicatorsConfig extends Config
 	default boolean cannonTxtDynamic()
 	{
 		return false;
+	}
+	//endregion
+
+	//region Inventory Options
+	@ConfigSection(
+		name = "Inventory",
+		description = "",
+		position = 4
+	)
+
+	String inventorySection = "Inventory";
+
+	@ConfigItem(
+		keyName = "inventory",
+		name = "Enable Inventory Count",
+		description = "Shows the amount of filled inventory slots.",
+		section = inventorySection,
+		position = 0
+	)
+
+	default boolean inventory()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "inventoryColor",
+		name = "Background Color",
+		description = "",
+		section = inventorySection,
+		position = 1
+	)
+
+	default Color inventoryColor()
+	{
+		return Color.decode("#845020");
+	}
+
+	@ConfigItem(
+		keyName = "inventoryTxtColor",
+		name = "Text Color",
+		description = "",
+		section = inventorySection,
+		position = 2
+	)
+
+	default Color inventoryTxtColor()
+	{
+		return Color.decode("#ffffff");
+	}
+
+	@ConfigItem(
+		keyName = "inventoryThreshold",
+		name = "Count Threshold",
+		description = "The amount of filled inventory slots at which the text color changes.",
+		section = inventorySection,
+		position = 3
+	)
+
+	default int inventoryThreshold()
+	{
+		return 20;
+	}
+
+	@ConfigItem(
+		keyName = "inventoryThresholdTxtColor",
+		name = "Threshold Text Color",
+		description = "The amount of filled inventory slots at which the text color changes.",
+		section = inventorySection,
+		position = 4
+	)
+
+	default Color inventoryTxtThresholdColor()
+	{
+		return Color.decode("#ff6a00");
+	}
+
+	@ConfigItem(
+		keyName = "inventoryFullTxtColor",
+		name = "Inventory Full Text Color",
+		description = "The color of the text when the inventory is full.",
+		section = inventorySection,
+		position = 5
+	)
+
+	default Color inventoryTxtFullColor()
+	{
+		return Color.decode("#00ff26");
+	}
+
+	@ConfigItem(
+		keyName = "inventoryEmptyTxtColor",
+		name = "Inventory Empty Text Color",
+		description = "The color of the text when the inventory is empty.",
+		section = inventorySection,
+		position = 6
+	)
+
+	default Color inventoryTxtEmptyColor()
+	{
+		return Color.decode("#ff0000");
 	}
 	//endregion
 }

--- a/src/main/java/com/trayindicators/TrayIndicatorsPlugin.java
+++ b/src/main/java/com/trayindicators/TrayIndicatorsPlugin.java
@@ -77,6 +77,7 @@ public class TrayIndicatorsPlugin extends Plugin
 			trayIcons.put(IconType.Prayer, new PrayerIcon(client, config));
 			trayIcons.put(IconType.Absorption, new AbsorptionIcon(client, config));
 			trayIcons.put(IconType.Cannon, new CannonIcon(client, config));
+			trayIcons.put(IconType.Inventory, new InventoryIcon(client, config));
 		}
 	}
 

--- a/src/main/java/com/trayindicators/icons/InventoryIcon.java
+++ b/src/main/java/com/trayindicators/icons/InventoryIcon.java
@@ -24,11 +24,63 @@
  */
 package com.trayindicators.icons;
 
-public enum IconType
+import com.trayindicators.TrayIndicatorsConfig;
+import java.awt.Color;
+import java.util.Arrays;
+import net.runelite.api.Client;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.InventoryID;
+
+public class InventoryIcon extends Icon
 {
-	Health,
-	Prayer,
-	Absorption,
-	Cannon,
-	Inventory
+	public InventoryIcon(Client client, TrayIndicatorsConfig config)
+	{
+		super(IconType.Inventory, client, config);
+	}
+
+	@Override
+	public IconData getIconData()
+	{
+		int filledSlots = getFilledInventorySlots();
+		Color txtColor = config.inventoryTxtColor();
+
+		if (filledSlots <= 0)
+		{
+			txtColor = config.inventoryTxtEmptyColor();
+		}
+		else if (filledSlots >= 28)
+		{
+			txtColor = config.inventoryTxtFullColor();
+		}
+		else if (filledSlots >= config.inventoryThreshold())
+		{
+			txtColor = config.inventoryTxtThresholdColor();
+		}
+
+		return new IconData(
+			filledSlots,
+			config.inventoryColor(),
+			txtColor
+		);
+	}
+
+	@Override
+	public boolean isActive()
+	{
+		return config.inventory();
+	}
+
+	private int getFilledInventorySlots()
+	{
+		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
+
+		if (inventory == null)
+		{
+			return 0;
+		}
+
+		return (int)Arrays.stream(inventory.getItems())
+			.filter(item -> item.getQuantity() > 0)
+			.count();
+	}
 }


### PR DESCRIPTION
Adds a new icon displaying the number of items in the inventory.

Features:
- Displays an icon with customizable background and foreground colors, showing the current number of items in the inventory.
- Allow the icon text color to change when the inventory is full or empty.
- Allows setting a threshold for the number of items, triggering a color change when that threshold is reached.