### PR TITLE
Add x/y offsets and text size controls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,3 +30,12 @@ tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
 	options.release.set(11)
 }
+
+tasks.register('runTest', JavaExec) {
+    group = 'runelite'
+    description = 'Runs RuneLite client with TrayIndicators plugin loaded for testing'
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = 'com.trayindicators.TrayIndicatorsPluginTest'
+    jvmArgs = ['-ea', '-Xmx2G']
+    args = ['--developer-mode', '--debug']
+}

--- a/src/main/java/com/trayindicators/TrayIndicatorsConfig.java
+++ b/src/main/java/com/trayindicators/TrayIndicatorsConfig.java
@@ -78,6 +78,18 @@ public interface TrayIndicatorsConfig extends Config
 	{
 		return Color.decode("#ffffff");
 	}
+
+  @ConfigItem(
+    keyName = "healthTxtSize",
+    name = "Text Size",
+    description = "",
+    section = healthSection,
+    position = 3
+  )
+  default int healthTxtSize()
+  {
+    return 12;
+  }
 	//endregion
 
 	//region Prayer Options
@@ -123,6 +135,19 @@ public interface TrayIndicatorsConfig extends Config
 	{
 		return Color.decode("#000000");
 	}
+
+	@ConfigItem(
+		keyName = "prayerTxtSize",
+		name = "Text Size",
+		description = "",
+		section = prayerSection,
+		position = 3
+	)
+	default int prayerTxtSize()
+	{
+		return 12;
+	}
+
 	//endregion
 
 	//region Absorption Options
@@ -169,6 +194,19 @@ public interface TrayIndicatorsConfig extends Config
 	default Color absorptionTxtColor()
 	{
 		return Color.decode("#000000");
+	}
+
+	@ConfigItem(
+		keyName = "absorptionTxtSize",
+		name = "Text Size",
+		description = "",
+		section = absorptionSection,
+		position = 3
+	)
+
+	default int absorptionTxtSize()
+	{
+		return 12;
 	}
 	//endregion
 
@@ -229,6 +267,19 @@ public interface TrayIndicatorsConfig extends Config
 	default boolean cannonTxtDynamic()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "cannonTxtSize",
+		name = "Text Size",
+		description = "",
+		section = cannonSection,
+		position = 4
+	)
+
+	default int cannonTxtSize()
+	{
+		return 12;
 	}
 	//endregion
 
@@ -331,6 +382,19 @@ public interface TrayIndicatorsConfig extends Config
 	{
 		return Color.decode("#ff0000");
 	}
+
+	@ConfigItem(
+		keyName = "inventoryTxtSize",
+		name = "Inventory Text Size",
+		description = "",
+		section = inventorySection,
+		position = 7
+	)
+
+	default int inventoryTxtSize()
+	{
+		return 12;
+	}
 	//endregion
 
 	//region Special Attack Options
@@ -405,6 +469,19 @@ public interface TrayIndicatorsConfig extends Config
 	default Color specProgressColor()
 	{
 		return Color.decode("#4398ae");
+	}
+
+	@ConfigItem(
+		keyName = "specTxtSize",
+		name = "Special Attack Text Size",
+		description = "",
+		section = specSection,
+		position = 5
+	)
+
+	default int specTxtSize()
+	{
+		return 12;
 	}
 	//endregion
 }

--- a/src/main/java/com/trayindicators/TrayIndicatorsConfig.java
+++ b/src/main/java/com/trayindicators/TrayIndicatorsConfig.java
@@ -90,6 +90,30 @@ public interface TrayIndicatorsConfig extends Config
   {
     return 12;
   }
+
+  @ConfigItem(
+    keyName = "healthXOffset",
+    name = "Text X Offset",
+    description = "",
+    section = healthSection,
+    position = 4
+  )
+  default int healthXOffset()
+  {
+    return 0;
+  }
+
+  @ConfigItem(
+    keyName = "healthYOffset",
+    name = "Text Y Offset",
+    description = "",
+    section = healthSection,
+    position = 5
+  )
+  default int healthYOffset()
+  {
+    return 0;
+  }
 	//endregion
 
 	//region Prayer Options
@@ -147,6 +171,31 @@ public interface TrayIndicatorsConfig extends Config
 	{
 		return 12;
 	}
+
+  @ConfigItem(
+    keyName = "prayerXOffset",
+    name = "Text X Offset",
+    description = "",
+    section = prayerSection,
+    position = 4
+  )
+  default int prayerXOffset()
+  {
+    return 0;
+  }
+
+  @ConfigItem(
+    keyName = "prayerYOffset",
+    name = "Text Y Offset",
+    description = "",
+    section = prayerSection,
+    position = 5
+  )
+  default int prayerYOffset()
+  {
+    return 0;
+  }
+
 
 	//endregion
 
@@ -208,6 +257,30 @@ public interface TrayIndicatorsConfig extends Config
 	{
 		return 12;
 	}
+
+  @ConfigItem(
+    keyName = "absorptionXOffset",
+    name = "Text X Offset",
+    description = "",
+    section = absorptionSection,
+    position = 4
+  )
+  default int absorptionXOffset()
+  {
+    return 0;
+  }
+
+  @ConfigItem(
+    keyName = "absorptionYOffset",
+    name = "Text Y Offset",
+    description = "",
+    section = absorptionSection,
+    position = 5
+  )
+  default int absorptionYOffset()
+  {
+    return 0;
+  }
 	//endregion
 
 	//region Cannonballs Options
@@ -281,6 +354,31 @@ public interface TrayIndicatorsConfig extends Config
 	{
 		return 12;
 	}
+
+  @ConfigItem(
+      keyName = "cannonXOffset",
+      name = "Text X Offset",
+      description = "",
+      section = cannonSection,
+      position = 5
+    )
+    default int cannonXOffset()
+    {
+      return 0;
+    }
+
+  @ConfigItem(
+      keyName = "cannonYOffset",
+      name = "Text Y Offset",
+      description = "",
+      section = cannonSection,
+      position = 6
+    )
+    default int cannonYOffset()
+    {
+      return 0;
+    }
+
 	//endregion
 
 	//region Inventory Options
@@ -394,7 +492,31 @@ public interface TrayIndicatorsConfig extends Config
 	default int inventoryTxtSize()
 	{
 		return 12;
-	}
+	} 
+
+  @ConfigItem(
+      keyName = "inventoryXOffset",
+      name = "Text X Offset",
+      description = "",
+      section = cannonSection,
+      position = 8
+  )
+  default int inventoryXOffset()
+  {
+    return 0;
+  }
+
+  @ConfigItem(
+      keyName = "inventoryYOffset",
+      name = "Text Y Offset",
+      description = "",
+      section = cannonSection,
+      position = 9
+  )
+  default int inventoryYOffset()
+  {
+    return 0;
+  }
 	//endregion
 
 	//region Special Attack Options
@@ -483,5 +605,29 @@ public interface TrayIndicatorsConfig extends Config
 	{
 		return 12;
 	}
+
+  @ConfigItem(
+      keyName = "specXOffset",
+      name = "Text X Offset",
+      description = "",
+      section = specSection,
+      position = 6
+  )
+  default int specXOffset()
+  {
+    return 0;
+  }
+
+  @ConfigItem(
+      keyName = "specYOffset",
+      name = "Text Y Offset",
+      description = "",
+      section = specSection,
+      position = 7
+  )
+  default int specYOffset()
+  {
+    return 0;
+  }
 	//endregion
 }

--- a/src/main/java/com/trayindicators/icons/AbsorptionIcon.java
+++ b/src/main/java/com/trayindicators/icons/AbsorptionIcon.java
@@ -44,7 +44,8 @@ public class AbsorptionIcon extends Icon
 		return new IconData(
 			client.getVarbitValue(Varbits.NMZ_ABSORPTION),
 			config.absorptionColor(),
-			config.absorptionTxtColor()
+			config.absorptionTxtColor(),
+      config.absorptionTxtSize()
 		);
 	}
 

--- a/src/main/java/com/trayindicators/icons/AbsorptionIcon.java
+++ b/src/main/java/com/trayindicators/icons/AbsorptionIcon.java
@@ -45,7 +45,9 @@ public class AbsorptionIcon extends Icon
 			client.getVarbitValue(Varbits.NMZ_ABSORPTION),
 			config.absorptionColor(),
 			config.absorptionTxtColor(),
-      config.absorptionTxtSize()
+      config.absorptionTxtSize(),
+      config.absorptionXOffset(),
+      config.absorptionYOffset()
 		);
 	}
 

--- a/src/main/java/com/trayindicators/icons/CannonIcon.java
+++ b/src/main/java/com/trayindicators/icons/CannonIcon.java
@@ -70,7 +70,8 @@ public class CannonIcon extends Icon
 		return new IconData(
 			value,
 			config.cannonColor(),
-			txtColor
+			txtColor,
+      config.cannonTxtSize()
 		);
 	}
 

--- a/src/main/java/com/trayindicators/icons/CannonIcon.java
+++ b/src/main/java/com/trayindicators/icons/CannonIcon.java
@@ -71,7 +71,9 @@ public class CannonIcon extends Icon
 			value,
 			config.cannonColor(),
 			txtColor,
-      config.cannonTxtSize()
+      config.cannonTxtSize(),
+      config.cannonXOffset(),
+      config.cannonYOffset()
 		);
 	}
 

--- a/src/main/java/com/trayindicators/icons/HealthIcon.java
+++ b/src/main/java/com/trayindicators/icons/HealthIcon.java
@@ -42,7 +42,9 @@ public class HealthIcon extends Icon
 			client.getBoostedSkillLevel(Skill.HITPOINTS),
 			config.healthColor(),
 			config.healthTxtColor(),
-      config.healthTxtSize()
+      config.healthTxtSize(),
+      config.healthXOffset(),
+      config.healthYOffset()
 		);
 	}
 

--- a/src/main/java/com/trayindicators/icons/HealthIcon.java
+++ b/src/main/java/com/trayindicators/icons/HealthIcon.java
@@ -41,7 +41,8 @@ public class HealthIcon extends Icon
 		return new IconData(
 			client.getBoostedSkillLevel(Skill.HITPOINTS),
 			config.healthColor(),
-			config.healthTxtColor()
+			config.healthTxtColor(),
+      config.healthTxtSize()
 		);
 	}
 

--- a/src/main/java/com/trayindicators/icons/Icon.java
+++ b/src/main/java/com/trayindicators/icons/Icon.java
@@ -55,14 +55,14 @@ public abstract class Icon
 		this.config = config;
 	}
 
-	private void createIcon(int value, Color bgColor, Color txtColor)
+	private void createIcon(int value, Color bgColor, Color txtColor, int txtSize)
 	{
 		if (trayIcon != null)
 		{
 			removeIcon();
 		}
 
-		trayIcon = new TrayIcon(createImage(value, bgColor, txtColor));
+		trayIcon = new TrayIcon(createImage(value, bgColor, txtColor, txtSize));
 		trayIcon.setImageAutoSize(true);
 
 		try
@@ -116,12 +116,12 @@ public abstract class Icon
 
 		if (trayIcon == null)
 		{
-			createIcon(data.value, data.bgColor, data.txtColor);
+			createIcon(data.value, data.bgColor, data.txtColor, data.txtSize);
 		}
 		else
 		{
 			trayIcon.getImage().flush();
-			trayIcon.setImage(createImage(data.value, data.bgColor, data.txtColor));
+			trayIcon.setImage(createImage(data.value, data.bgColor, data.txtColor, data.txtSize));
 		}
 
 		if (cacheImage)
@@ -141,7 +141,7 @@ public abstract class Icon
 		trayIcon = null;
 	}
 
-	protected BufferedImage createImage(int value, Color bgColor, Color txtColor)
+	protected BufferedImage createImage(int value, Color bgColor, Color txtColor, int txtSize)
 	{
 		int size = 16;
 		String text = Integer.toString(value);
@@ -156,8 +156,7 @@ public abstract class Icon
 		// Draw text
 		graphics.setColor(txtColor);
 
-		int fontSize = (text.length() >= 4) ? 8 : (text.length() == 3) ? 9 : 12;
-		graphics.setFont(new Font(graphics.getFont().getName(), Font.PLAIN, fontSize));
+		graphics.setFont(new Font(graphics.getFont().getName(), Font.PLAIN, txtSize));
 
 		FontMetrics metrics = graphics.getFontMetrics();
 		int x = (size - metrics.stringWidth(text)) / 2;

--- a/src/main/java/com/trayindicators/icons/Icon.java
+++ b/src/main/java/com/trayindicators/icons/Icon.java
@@ -37,138 +37,116 @@ import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.client.events.ConfigChanged;
 
 @Slf4j
-public abstract class Icon
-{
-	public final IconType type;
+public abstract class Icon {
+  public final IconType type;
 
-	protected final Client client;
-	protected final TrayIndicatorsConfig config;
+  protected final Client client;
+  protected final TrayIndicatorsConfig config;
 
-	private TrayIcon trayIcon;
-	protected IconData lastIconData;
-	protected boolean cacheImage = true;
+  private TrayIcon trayIcon;
+  protected IconData lastIconData;
+  protected boolean cacheImage = true;
 
-	public Icon(IconType type, Client client, TrayIndicatorsConfig config)
-	{
-		this.type = type;
-		this.client = client;
-		this.config = config;
-	}
+  public Icon(IconType type, Client client, TrayIndicatorsConfig config) {
+    this.type = type;
+    this.client = client;
+    this.config = config;
+  }
 
-	private void createIcon(int value, Color bgColor, Color txtColor, int txtSize)
-	{
-		if (trayIcon != null)
-		{
-			removeIcon();
-		}
+  private void createIcon(int value, Color bgColor, Color txtColor, int txtSize, int xOffset, int yOffset) {
+    if (trayIcon != null) {
+      removeIcon();
+    }
 
-		trayIcon = new TrayIcon(createImage(value, bgColor, txtColor, txtSize));
-		trayIcon.setImageAutoSize(true);
+    trayIcon = new TrayIcon(createImage(value, bgColor, txtColor, txtSize, xOffset, yOffset));
+    trayIcon.setImageAutoSize(true);
 
-		try
-		{
-			SystemTray.getSystemTray().add(trayIcon);
-		}
-		catch (AWTException ex)
-		{
-			log.error("Unable to add system tray icon.", ex);
-		}
-	}
+    try {
+      SystemTray.getSystemTray().add(trayIcon);
+    } catch (AWTException ex) {
+      log.error("Unable to add system tray icon.", ex);
+    }
+  }
 
-	public void onGameTick(GameTick event)
-	{
-		updateIcon();
-	}
+  public void onGameTick(GameTick event) {
+    updateIcon();
+  }
 
-	public void onGameStateChanged(GameStateChanged event)
-	{
-		if (event.getGameState() == GameState.LOGIN_SCREEN)
-		{
-			removeIcon();
-		}
-	}
+  public void onGameStateChanged(GameStateChanged event) {
+    if (event.getGameState() == GameState.LOGIN_SCREEN) {
+      removeIcon();
+    }
+  }
 
-	public void onConfigChanged(ConfigChanged event)
-	{
-		updateIcon();
-	}
+  public void onConfigChanged(ConfigChanged event) {
+    updateIcon();
+  }
 
-	public void onItemContainerChanged(ItemContainerChanged event)
-	{
-		// Default implementation does nothing
-		// Subclasses can override this method if needed
-	}
+  public void onItemContainerChanged(ItemContainerChanged event) {
+    // Default implementation does nothing
+    // Subclasses can override this method if needed
+  }
 
-	public void updateIcon()
-	{
-		if (!isActive())
-		{
-			removeIcon();
-			return;
-		}
+  public void updateIcon() {
+    if (!isActive()) {
+      removeIcon();
+      return;
+    }
 
-		IconData data = getIconData();
+    IconData data = getIconData();
 
-		if (cacheImage && trayIcon != null && data.equals(lastIconData))
-		{
-			return;
-		}
+    if (cacheImage && trayIcon != null && data.equals(lastIconData)) {
+      return;
+    }
 
-		if (trayIcon == null)
-		{
-			createIcon(data.value, data.bgColor, data.txtColor, data.txtSize);
-		}
-		else
-		{
-			trayIcon.getImage().flush();
-			trayIcon.setImage(createImage(data.value, data.bgColor, data.txtColor, data.txtSize));
-		}
+    if (trayIcon == null) {
+      createIcon(data.value, data.bgColor, data.txtColor, data.txtSize, data.xOffset, data.yOffset);
+    } else {
+      trayIcon.getImage().flush();
+      trayIcon.setImage(createImage(data.value, data.bgColor, data.txtColor, data.txtSize, data.xOffset, data.yOffset));
+    }
 
-		if (cacheImage)
-		{
-			lastIconData = data;
-		}
-	}
+    if (cacheImage) {
+      lastIconData = data;
+    }
+  }
 
-	public void removeIcon()
-	{
-		if (trayIcon == null)
-		{
-			return;
-		}
+  public void removeIcon() {
+    if (trayIcon == null) {
+      return;
+    }
 
-		SystemTray.getSystemTray().remove(trayIcon);
-		trayIcon = null;
-	}
+    SystemTray.getSystemTray().remove(trayIcon);
+    trayIcon = null;
+  }
 
-	protected BufferedImage createImage(int value, Color bgColor, Color txtColor, int txtSize)
-	{
-		int size = 16;
-		String text = Integer.toString(value);
+  protected BufferedImage createImage(int value, Color bgColor, Color txtColor, int txtSize, int xOffset, int yOffset) {
+    int size = 16;
+    String text = Integer.toString(value);
 
-		BufferedImage image = new BufferedImage(size, size, BufferedImage.TYPE_4BYTE_ABGR);
-		Graphics2D graphics = image.createGraphics();
+    BufferedImage image = new BufferedImage(size, size, BufferedImage.TYPE_4BYTE_ABGR);
+    Graphics2D graphics = image.createGraphics();
 
-		// Draw background
-		graphics.setColor(bgColor);
-		graphics.fillRect(0, 0, size, size);
+    // Draw background
+    graphics.setColor(bgColor);
+    graphics.fillRect(0, 0, size, size);
 
-		// Draw text
-		graphics.setColor(txtColor);
+    // Draw text
+    graphics.setColor(txtColor);
 
-		graphics.setFont(new Font(graphics.getFont().getName(), Font.PLAIN, txtSize));
+    graphics.setFont(new Font(graphics.getFont().getName(), Font.PLAIN, txtSize));
 
-		FontMetrics metrics = graphics.getFontMetrics();
-		int x = (size - metrics.stringWidth(text)) / 2;
-		int y = ((size - metrics.getHeight()) / 2) + metrics.getAscent();
-		graphics.drawString(text, x, y);
+    FontMetrics metrics = graphics.getFontMetrics();
+    int x = ((size - metrics.stringWidth(text)) / 2) - xOffset;
+    int y = ((size - metrics.getHeight()) / 2) + metrics.getAscent() - yOffset;
+    graphics.drawString(text, x, y);
 
-		graphics.dispose();
+    graphics.dispose();
 
-		return image;
-	}
+    return image;
+  }
 
-	public abstract IconData getIconData();
+  public abstract IconData getIconData();
 
-	public abstract boolean isActive();
+  public abstract boolean isActive();
 }

--- a/src/main/java/com/trayindicators/icons/IconData.java
+++ b/src/main/java/com/trayindicators/icons/IconData.java
@@ -6,10 +6,11 @@ import lombok.EqualsAndHashCode;
 
 @AllArgsConstructor
 @EqualsAndHashCode
-public class IconData
-{
-	public int value;
-	public Color bgColor;
-	public Color txtColor;
+public class IconData {
+  public int value;
+  public Color bgColor;
+  public Color txtColor;
   public int txtSize;
+  public int xOffset;
+  public int yOffset;
 }

--- a/src/main/java/com/trayindicators/icons/IconData.java
+++ b/src/main/java/com/trayindicators/icons/IconData.java
@@ -11,4 +11,5 @@ public class IconData
 	public int value;
 	public Color bgColor;
 	public Color txtColor;
+  public int txtSize;
 }

--- a/src/main/java/com/trayindicators/icons/InventoryIcon.java
+++ b/src/main/java/com/trayindicators/icons/InventoryIcon.java
@@ -60,7 +60,8 @@ public class InventoryIcon extends Icon
 		return new IconData(
 			filledSlots,
 			config.inventoryColor(),
-			txtColor
+			txtColor,
+      config.inventoryTxtSize()
 		);
 	}
 

--- a/src/main/java/com/trayindicators/icons/InventoryIcon.java
+++ b/src/main/java/com/trayindicators/icons/InventoryIcon.java
@@ -31,14 +31,12 @@ import net.runelite.api.Client;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.InventoryID;
 
-public class InventoryIcon extends Icon
-{
-	public InventoryIcon(Client client, TrayIndicatorsConfig config)
-	{
-		super(IconType.Inventory, client, config);
-	}
+public class InventoryIcon extends Icon {
+  public InventoryIcon(Client client, TrayIndicatorsConfig config) {
+    super(IconType.Inventory, client, config);
+  }
 
-	@Override
+  @Override
 	public IconData getIconData()
 	{
 		int filledSlots = getFilledInventorySlots();
@@ -61,33 +59,31 @@ public class InventoryIcon extends Icon
 			filledSlots,
 			config.inventoryColor(),
 			txtColor,
-      config.inventoryTxtSize()
+      config.inventoryTxtSize(),
+      config.inventoryXOffset(),
+      config.inventoryYOffset()
 		);
 	}
 
-	@Override
-	public boolean isActive()
-	{
-		return config.inventory();
-	}
+  @Override
+  public boolean isActive() {
+    return config.inventory();
+  }
 
-	private int getFilledInventorySlots()
-	{
-		// Make sure we are on the client thread
-		if (!client.isClientThread())
-		{
-			return 0;
-		}
+  private int getFilledInventorySlots() {
+    // Make sure we are on the client thread
+    if (!client.isClientThread()) {
+      return 0;
+    }
 
-		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
+    ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
 
-		if (inventory == null)
-		{
-			return 0;
-		}
+    if (inventory == null) {
+      return 0;
+    }
 
-		return (int)Arrays.stream(inventory.getItems())
-			.filter(item -> item.getQuantity() > 0)
-			.count();
-	}
+    return (int) Arrays.stream(inventory.getItems())
+        .filter(item -> item.getQuantity() > 0)
+        .count();
+  }
 }

--- a/src/main/java/com/trayindicators/icons/PrayerIcon.java
+++ b/src/main/java/com/trayindicators/icons/PrayerIcon.java
@@ -42,7 +42,9 @@ public class PrayerIcon extends Icon
 			client.getBoostedSkillLevel(Skill.PRAYER),
 			config.prayerColor(),
 			config.prayerTxtColor(),
-      config.prayerTxtSize()
+      config.prayerTxtSize(),
+      config.prayerXOffset(),
+      config.prayerYOffset()
 		);
 	}
 

--- a/src/main/java/com/trayindicators/icons/PrayerIcon.java
+++ b/src/main/java/com/trayindicators/icons/PrayerIcon.java
@@ -41,7 +41,8 @@ public class PrayerIcon extends Icon
 		return new IconData(
 			client.getBoostedSkillLevel(Skill.PRAYER),
 			config.prayerColor(),
-			config.prayerTxtColor()
+			config.prayerTxtColor(),
+      config.prayerTxtSize()
 		);
 	}
 

--- a/src/main/java/com/trayindicators/icons/SpecIcon.java
+++ b/src/main/java/com/trayindicators/icons/SpecIcon.java
@@ -58,7 +58,8 @@ public class SpecIcon extends Icon
 		return new IconData(
 			client.getVarpValue(VarPlayer.SPECIAL_ATTACK_PERCENT) / 10,
 			config.specColor(),
-			config.specTxtColor()
+			config.specTxtColor(),
+      config.specTxtSize()
 		);
 	}
 
@@ -112,11 +113,11 @@ public class SpecIcon extends Icon
 	}
 
 	@Override
-	protected BufferedImage createImage(int value, Color bgColor, Color txtColor) {
+	protected BufferedImage createImage(int value, Color bgColor, Color txtColor, int txtSize) {
 		// Use the default image creation if we don't have to draw the progress bar.
 		if (!config.specProgress())
 		{
-			return super.createImage(value, bgColor, txtColor);
+			return super.createImage(value, bgColor, txtColor, txtSize);
 		}
 
 		final int ticksPerSpecRegen = wearingLightbearer ? LIGHTBEARER_REGEN_TICKS : SPEC_REGEN_TICKS;
@@ -142,8 +143,7 @@ public class SpecIcon extends Icon
 		// Draw text
 		graphics.setColor(txtColor);
 
-		int fontSize = (text.length() >= 4) ? 8 : (text.length() == 3) ? 9 : 12;
-		graphics.setFont(new Font(graphics.getFont().getName(), Font.PLAIN, fontSize));
+		graphics.setFont(new Font(graphics.getFont().getName(), Font.PLAIN, txtSize));
 
 		FontMetrics metrics = graphics.getFontMetrics();
 		int x = (size - metrics.stringWidth(text)) / 2;

--- a/src/main/java/com/trayindicators/icons/SpecIcon.java
+++ b/src/main/java/com/trayindicators/icons/SpecIcon.java
@@ -59,7 +59,9 @@ public class SpecIcon extends Icon
 			client.getVarpValue(VarPlayer.SPECIAL_ATTACK_PERCENT) / 10,
 			config.specColor(),
 			config.specTxtColor(),
-      config.specTxtSize()
+      config.specTxtSize(),
+      config.specXOffset(),
+      config.specYOffset()
 		);
 	}
 
@@ -113,11 +115,11 @@ public class SpecIcon extends Icon
 	}
 
 	@Override
-	protected BufferedImage createImage(int value, Color bgColor, Color txtColor, int txtSize) {
+	protected BufferedImage createImage(int value, Color bgColor, Color txtColor, int txtSize, int xOffset, int yOffset) {
 		// Use the default image creation if we don't have to draw the progress bar.
 		if (!config.specProgress())
 		{
-			return super.createImage(value, bgColor, txtColor, txtSize);
+			return super.createImage(value, bgColor, txtColor, txtSize, xOffset, yOffset);
 		}
 
 		final int ticksPerSpecRegen = wearingLightbearer ? LIGHTBEARER_REGEN_TICKS : SPEC_REGEN_TICKS;


### PR DESCRIPTION
I use linux and the tray icons were slightly offset and didn't look right.
I added controls to the config to support moving the text around the icon as well as adjusting the text sizes.